### PR TITLE
Add CopyTextView and update ACopyText.vue component

### DIFF
--- a/src/components/ACopyText.vue
+++ b/src/components/ACopyText.vue
@@ -5,6 +5,7 @@ import { isNumber, isString } from '@/utils/common'
 import { useI18n } from 'vue-i18n'
 import { useAlerts } from '@/composables/system/alerts'
 import { numberToString } from '@/utils/number'
+import { withModifiers } from 'vue'
 
 const props = withDefaults(
   defineProps<{
@@ -40,8 +41,10 @@ const onClick = (event: Event) => {
 <template>
   <slot
     name="activator"
-    :on-click="onClick"
-    :is-supported="isSupported"
+    :props="{
+      onClick: withModifiers((e) => onClick(e), ['stop']),
+      disabled: !isSupported
+    }"
   >
     <div
       :class="{ 'cursor-pointer': isSupported }"

--- a/src/components/ACopyText.vue
+++ b/src/components/ACopyText.vue
@@ -38,26 +38,32 @@ const onClick = (event: Event) => {
 </script>
 
 <template>
-  <div
-    :class="{ 'cursor-pointer': isSupported }"
-    :data-cy="dataCy"
-    class="d-inline-flex align-center anzu-copy-text"
-    @click.stop="onClick"
+  <slot
+    name="activator"
+    :on-click="onClick"
+    :is-supported="isSupported"
   >
-    <span>{{ value }}</span>
-    <VIcon
-      v-if="isSupported"
-      class="ml-1"
-      size="x-small"
-      icon="mdi-content-copy"
-    />
-    <VTooltip
-      activator="parent"
-      location="bottom"
+    <div
+      :class="{ 'cursor-pointer': isSupported }"
+      :data-cy="dataCy"
+      class="d-inline-flex align-center anzu-copy-text"
+      @click.stop="onClick"
     >
-      Copy
-    </VTooltip>
-  </div>
+      <span>{{ value }}</span>
+      <VIcon
+        v-if="isSupported"
+        class="ml-1"
+        size="x-small"
+        icon="mdi-content-copy"
+      />
+      <VTooltip
+        activator="parent"
+        location="bottom"
+      >
+        Copy
+      </VTooltip>
+    </div>
+  </slot>
 </template>
 
 <style lang="scss">

--- a/src/playground/copyTextView/CopyTextView.vue
+++ b/src/playground/copyTextView/CopyTextView.vue
@@ -22,11 +22,10 @@ const copyTextThird = ref('copyTextThird')
       <VRow>
         <VCol cols="4">
           <ACopyText :value="copyTextSecond">
-            <template #activator="{ onClick, isSupported }">
+            <template #activator="{ props }">
               <ABtnPrimary
-                :disabled="!isSupported"
                 text="Click me to copy"
-                @click.stop="onClick"
+                v-bind="props"
               />
             </template>
           </ACopyText>
@@ -35,10 +34,9 @@ const copyTextThird = ref('copyTextThird')
       <VRow>
         <VCol cols="4">
           <ACopyText :value="copyTextThird">
-            <template #activator="{ onClick, isSupported }">
+            <template #activator="{ props }">
               <VBtn
-                :disabled="!isSupported"
-                @click.stop="onClick"
+                v-bind="props"
               >
                 <VIcon icon="mdi-content-copy" />
               </VBtn>

--- a/src/playground/copyTextView/CopyTextView.vue
+++ b/src/playground/copyTextView/CopyTextView.vue
@@ -1,0 +1,51 @@
+<script setup lang="ts">
+import ActionbarWrapper from '@/playground/system/ActionbarWrapper.vue'
+import { ref } from 'vue'
+import ACopyText from '@/components/ACopyText.vue'
+
+const copyTextFirst = ref('copyTextFirst')
+const copyTextSecond = ref('copyTextSecond')
+const copyTextThird = ref('copyTextThird')
+
+</script>
+
+<template>
+  <ActionbarWrapper />
+  <VCard>
+    <VCardTitle>Copy text</VCardTitle>
+    <VCardText>
+      <VRow>
+        <VCol cols="4">
+          <ACopyText :value="copyTextFirst" />
+        </VCol>
+      </VRow>
+      <VRow>
+        <VCol cols="4">
+          <ACopyText :value="copyTextSecond">
+            <template #activator="{ onClick, isSupported }">
+              <ABtnPrimary
+                :disabled="!isSupported"
+                text="Click me to copy"
+                @click.stop="onClick"
+              />
+            </template>
+          </ACopyText>
+        </VCol>
+      </VRow>
+      <VRow>
+        <VCol cols="4">
+          <ACopyText :value="copyTextThird">
+            <template #activator="{ onClick, isSupported }">
+              <VBtn
+                :disabled="!isSupported"
+                @click.stop="onClick"
+              >
+                <VIcon icon="mdi-content-copy" />
+              </VBtn>
+            </template>
+          </ACopyText>
+        </VCol>
+      </VRow>
+    </VCardText>
+  </VCard>
+</template>

--- a/src/router/playground.ts
+++ b/src/router/playground.ts
@@ -33,6 +33,7 @@ import { useCommonAdminCollabOptions } from '@/components/collab/composables/com
 import { useAlerts } from '@/composables/system/alerts'
 import { useCollabRoom } from '@/components/collab/composables/collabRoom'
 import { updateCurrentUser, useCurrentUser } from '@/playground/collabView/currentUser'
+import CopyTextView from '@/playground/copyTextView/CopyTextView.vue'
 
 const { createCollabRoom } = useCollabHelpers()
 
@@ -53,6 +54,11 @@ const router = createRouter({
       path: '/view/boolean-value',
       name: 'view-boolean-value',
       component: BooleanValueView,
+    },
+    {
+      path: '/view/copy-text',
+      name: 'view-copy-text',
+      component: CopyTextView,
     },
     {
       path: '/view/permission',


### PR DESCRIPTION
Introduced a new CopyTextView in the router for '/view/copy-text' path. A new file 'CopyTextView.vue' is added to 'playground' where a custom action bar wrapper with ACopyText component is used. Also, the component 'ACopyText.vue' is updated for better slot usage.